### PR TITLE
feat(build): enable component synth for Agilex 3 devices

### DIFF
--- a/build/targets/comp_quartus.tcl
+++ b/build/targets/comp_quartus.tcl
@@ -69,6 +69,7 @@ if {![info exists SYNTH_FLAGS(FPGA)]} {
     }
     set SYNTH_FLAGS(FPGA) [string map {
             "STRATIX10"     "1SD280PT2F55E1VG"
+            "AGILEX3"       "A3CZ135BB18AE7S"
             "AGILEX"        "AGIB027R29A1E2VR0"
         } $SYNTH_FLAGS(DEVICE)]
 }


### PR DESCRIPTION
This will allow users to synthesize components without having a license. This FPGA part is on new[ Atum A3 Nano board from Terasic](https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&No=1373&PartNo=1).

Targeting Agilex7 works as before.